### PR TITLE
Fix arg parsing

### DIFF
--- a/bandoleers/args.py
+++ b/bandoleers/args.py
@@ -1,0 +1,52 @@
+import argparse
+import logging
+import sys
+
+import bandoleers
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    """
+    Implements some common command-line behaviors.
+
+    This is a slightly extended version of the standard
+    :class:`argparse.ArgumentParser` class that does three
+    things for you:
+
+    * exits with a non-zero status when help is shown
+    * implements --quiet and --verbose mutually exclusive
+      options that call :meth:`logging.Logger.setLevel` on
+      the root logger
+    * adds a --version flag
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(ArgumentParser, self).__init__(*args, **kwargs)
+        output_control = self.add_mutually_exclusive_group()
+        output_control.add_argument('-q', '--quiet',
+                                    action='store_true', default=False,
+                                    help='disable non-failure output')
+        output_control.add_argument('-v', '--verbose',
+                                    action='store_true', default=False,
+                                    help='show diagnostic output')
+        self.add_argument('--version', action='version',
+                          version='%(prog)s {}'.format(bandoleers.__version__))
+
+    def parse_args(self, *args, **kwargs):
+        result = super(ArgumentParser, self).parse_args(*args, **kwargs)
+        if result.verbose:
+            logging.getLogger().setLevel(logging.DEBUG)
+        if result.quiet:
+            logging.getLogger().setLevel(logging.ERROR)
+        return result
+
+    def print_usage(self, file=None):
+        stream = file or sys.stdout
+        stream.write(self.format_usage())
+        sys.exit(64)
+
+    def print_help(self, file=None):
+        stream = file or sys.stdout
+        stream.write(self.format_help())
+        sys.exit(64)

--- a/bandoleers/prepit.py
+++ b/bandoleers/prepit.py
@@ -1,4 +1,5 @@
-""" Prepit platform service configuration utility.
+"""
+Platform service configuration utility.
 
 The prepit utility looks for a set of configuratione files in a local
 directory called platform, and attempts to apply those configuration
@@ -22,6 +23,8 @@ import consulate
 import json
 import queries
 import requests
+
+from bandoleers import args
 
 
 LOGGER = logging.getLogger(__name__)
@@ -131,8 +134,13 @@ def prep_rabbit(file):
 
 def run():
     logging.basicConfig(
-        level=logging.DEBUG,
+        level=logging.INFO,
         format='%(levelname)1.1s - %(name)s: %(message)s')
+    parser = args.ArgumentParser()
+    parser.add_argument('-d', '--dir', metavar='DIRECTORY',
+                        default='platform', dest='directory',
+                        help='read files from DIRECTORY')
+    opts = parser.parse_args()
 
     resources = {
         'cassandra': prep_cassandra,
@@ -142,13 +150,13 @@ def run():
         'redis': prep_redis,
     }
 
-    dir = os.listdir('./platform')
+    top_level = os.listdir(opts.directory)
     for resource in resources:
-        if resource in dir:
-            path = '/'.join(['./platform', resource])
+        if resource in top_level:
+            path = '/'.join([opts.directory, resource])
             files = os.listdir(path)
-            for file in files:
-                resources[resource]('/'.join([path, file]))
+            for data_file in files:
+                resources[resource]('/'.join([path, data_file]))
     LOGGER.info('Finished processing successfully.')
     sys.exit(0)
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,8 @@ Release History
 `Next Release`_
 ---------------
 - Make the platform directory name an option for ``prep-it``
+- Add ``--sleep`` parameter to ``wait-for``
+- Normalize parameter processing between commands
 
 `1.0.0`_ (2016-01-27)
 ---------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Make the platform directory name an option for ``prep-it``
+
 `1.0.0`_ (2016-01-27)
 ---------------------
 - Infect the world!

--- a/docs/prep-it.rst
+++ b/docs/prep-it.rst
@@ -6,6 +6,33 @@ The :program:`prep-it` utility scans the *platform* sub-directory and
 loads data files into various backends.  The following sections describe
 each directory name that is supported and its expected content.
 
+.. code::
+
+   prep-it ([-q|--quiet] | [-v|--verbose]) [-d|--dir DIRECTORY]
+   prep-it (-h | --help | --version)
+
+.. option:: DIRECTORY
+
+   Specifies the directory to process.  If unspecified, the "platform"
+   directory is processed.
+
+.. option:: -v, --verbose
+
+   Write diagnostics to standard output.  Without this flag, informational
+   messages will be displayed.
+
+.. option:: -q, --quiet
+
+   Only show output when an error occurs.
+
+.. option:: -h, --help
+
+   Display a usage synopsis and exit with a failure status.
+
+.. option:: --version
+
+   Display the package version and exit with a failure status.
+
 cassandra
 ---------
 Text files containing queries that are executed using a

--- a/docs/wait-for.rst
+++ b/docs/wait-for.rst
@@ -7,7 +7,8 @@ successful response.
 
 .. code::
 
-   wait-for [-t|--timeout seconds] [-v|--verbose] URL
+   wait-for ([-q|--quiet] | [-v|--verbose]) [-s|--sleep SECONDS]
+            [-t|--timeout SECONDS] URL
    wait-for (-h | --help | --version)
 
 .. option:: URL
@@ -24,6 +25,10 @@ successful response.
    |                     | URL succeeds.                                |
    +---------------------+----------------------------------------------+
 
+.. option:: -s <seconds>, --sleep <seconds>
+
+   Sleep for the specified number of seconds between hitting the URL.
+
 .. option:: -t <seconds>, --timeout <seconds>
 
    Timeout and exit unsuccessfully if a successful response is not received
@@ -33,6 +38,10 @@ successful response.
 
    Write diagnostics to standard output.  Without this flag, the utility
    is quite silent.
+
+.. option:: -q, --quiet
+
+   Only show output when an error occurs.
 
 .. option:: -h, --help
 

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,6 +1,5 @@
 cassandra-driver>=2.5.1,<3.0
 consulate>=0.5.1,<2.0
-docopt>=0.6.1,<0.7
 psycopg2>=2.6,<3.0
 queries>=1.7.3,<2.0
 requests>=2.5.1,<3.0


### PR DESCRIPTION
The usage of [docopt] in `wait-for` was broken in that you had to specify the options _after_ the target URL and `prep-it` had all of the useful options hard-coded in it.  This PR switches both over the using [argparse] as well as implementing common handling for `--quiet`, `--verbose`, `--version`, and `--help`.

[argparse]: https://docs.python.org/2/library/argparse.html
[docopt]: http://docopt.org/