### PR TITLE
Skip postgres DB creation when a db-specific env var exists

### DIFF
--- a/bandoleers/prepit.py
+++ b/bandoleers/prepit.py
@@ -102,11 +102,10 @@ def prep_postgres(file):
             base = os.environ.get('PGSQL',
                                   'postgresql://postgres@localhost:5432')
             uri = os.path.join(base, db)
-
-        with queries.Session(os.path.join(base, 'postgres')) as session:
-            LOGGER.debug('Creating database')
-            session.query('DROP DATABASE IF EXISTS {};'.format(db))
-            session.query('CREATE DATABASE {};'.format(db))
+            with queries.Session(os.path.join(base, 'postgres')) as session:
+                LOGGER.debug('Creating database')
+                session.query('DROP DATABASE IF EXISTS {};'.format(db))
+                session.query('CREATE DATABASE {};'.format(db))
 
         with queries.Session(uri) as session:
             with open(file) as fh:

--- a/bandoleers/prepit.py
+++ b/bandoleers/prepit.py
@@ -9,7 +9,7 @@ for more details.
 
 """
 import logging
-import os
+import os.path
 import socket
 import sys
 try:
@@ -93,7 +93,7 @@ def prep_consul(file):
 def prep_postgres(file):
     try:
         LOGGER.info('Processing %s', file)
-        db = file.split('/')[-1][:-4]
+        db = os.path.splitext(os.path.basename(file))[0]
         uri = os.environ.get('PGSQL_{}'.format(db.upper()))
         if uri is not None:
             chop = len(db) + 1
@@ -101,11 +101,13 @@ def prep_postgres(file):
         else:
             base = os.environ.get('PGSQL',
                                   'postgresql://postgres@localhost:5432')
-            uri = base + '/' + db
-        with queries.Session(base + '/postgres') as session:
+            uri = os.path.join(base, db)
+
+        with queries.Session(os.path.join(base, 'postgres')) as session:
             LOGGER.debug('Creating database')
             session.query('DROP DATABASE IF EXISTS {};'.format(db))
             session.query('CREATE DATABASE {};'.format(db))
+
         with queries.Session(uri) as session:
             with open(file) as fh:
                 session.query(fh.read())

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -33,11 +33,15 @@ Environment Variables
    Identifies the redis server, port, and database to connect to.  This
    value follows the IANA-registered `redis url`_ format.
 
-
 .. envvar:: PGSQL
 
    Identifies the PostgreSQL server to connect to using the standard
    `postgresql:// scheme`_
+
+.. envvar:: PGSQL_...
+
+   Identifies the PostgreSQL connection to use for the specific database
+   named by the suffix using the standard `postgresql:// scheme`_
 
 
 .. _postgresql:// scheme: http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,8 @@ Release History
 - Make the platform directory name an option for ``prep-it``
 - Add ``--sleep`` parameter to ``wait-for``
 - Normalize parameter processing between commands
+- Do not create a postgres database if the database-specific
+  environment variable exists.
 
 `1.0.0`_ (2016-01-27)
 ---------------------

--- a/docs/prep-it.rst
+++ b/docs/prep-it.rst
@@ -102,4 +102,10 @@ database name is based on the file name minus the assumed ``.sql``
 suffix.  The database will be dropped if it exists and then created
 anew before running the SQL commands from the file.
 
+The database connection for a specific database can also be specified
+by setting the :envvar:`PGSQL_$DBNAME` environment variable where
+``$DBNAME`` is the name of the database in upper-case.  If a database
+specific environment variable exists, **then the database will not be
+created automatically.**
+
 .. _queries: https://github.com/gmr/queries


### PR DESCRIPTION
This PR changes the actual (undocumented) behavior when a database specific Postgres environment variable exists.  The documented behavior is to always use the `PGSQL` environment variable and create the database based on the filename.  IOW, _platform/postgres/app.sql_ will result in creating the `app` database using the DSN from the `PGSQL` environment variable.  We also allowed customizing each connection by specifying an environment variable that includes the database name (e.g, `PGSQL_APP`).

This PR skips database creation if the database-specific environment variable exists.  This makes it possible to use *prep-it* to load fixture data into an existing database server.