### PR TITLE
tcp:// support in wait-for

### DIFF
--- a/bandoleers/waitfor.py
+++ b/bandoleers/waitfor.py
@@ -124,29 +124,25 @@ def run():
 
     while True:
         try:
-            try:
-                connect_to(opts.URL, timeout=timeout)
-                logger.debug('connection to %s succeeded after %f seconds',
-                             opts.URL, time.time() - t0)
-                sys.exit(0)
+            connect_to(opts.URL, timeout=timeout)
+            logger.debug('connection to %s succeeded after %f seconds',
+                         opts.URL, time.time() - t0)
+            sys.exit(0)
 
-            except RuntimeError:
-                logger.exception('internal failure')
-                sys.exit(70)
-
-            except KeyboardInterrupt:
-                raise
-
-            except Exception as error:
-                if not wait_forever and (time.time() - t0) >= opts.timeout:
-                    break
-
-                logger.debug('%r, sleeping for %f seconds', error, opts.sleep)
-                time.sleep(opts.sleep)
+        except RuntimeError:
+            logger.exception('internal failure')
+            sys.exit(70)
 
         except KeyboardInterrupt:
             logger.info('killed')
             sys.exit(-1)
+
+        except Exception as error:
+            if not wait_forever and (time.time() - t0) >= opts.timeout:
+                break
+
+            logger.debug('%r, sleeping for %f seconds', error, opts.sleep)
+            time.sleep(opts.sleep)
 
     logger.error('wait timed out after %f seconds', time.time() - t0)
     sys.exit(-1)

--- a/bandoleers/waitfor.py
+++ b/bandoleers/waitfor.py
@@ -30,7 +30,6 @@ def connect_to(url, timeout):
     if scheme in ('http', 'https'):
         response = requests.get(url, timeout=timeout)
         response.raise_for_status()
-        return True
 
     elif scheme == 'cassandra':
         host, _, port = netloc.partition(':')
@@ -49,8 +48,6 @@ def connect_to(url, timeout):
         conn.connect()
         asyncore.close_all()
         asyncore.loop()
-
-        return True
 
     elif scheme == 'postgresql':
         kwargs = {
@@ -80,7 +77,6 @@ def connect_to(url, timeout):
         LOGGER.debug('connecting to postgres with %r', kwargs)
         conn = psycopg2.connect(**kwargs)
         conn.close()
-        return True
 
     elif scheme == 'tcp':
         host, sep, port = netloc.partition(':')
@@ -98,7 +94,6 @@ def connect_to(url, timeout):
         sock.settimeout(timeout)
         sock.connect((ip_addr, port))
         sock.close()
-        return True
 
     else:
         raise RuntimeError("I don't know what to do with {0}".format(scheme))
@@ -128,10 +123,10 @@ def run():
                  'forever' if wait_forever else opts.timeout)
     while wait_forever or (time.time() - t0) < opts.timeout:
         try:
-            if connect_to(opts.URL, timeout=timeout):
-                logger.debug('connection to %s succeeded after %f seconds',
-                             opts.URL, time.time() - t0)
-                sys.exit(0)
+            connect_to(opts.URL, timeout=timeout)
+            logger.debug('connection to %s succeeded after %f seconds',
+                         opts.URL, time.time() - t0)
+            sys.exit(0)
 
         except RuntimeError:
             logger.exception('internal failure')

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -10,6 +10,7 @@ Release History
 - Normalize parameter processing between commands
 - Do not create a postgres database if the database-specific
   environment variable exists.
+- Add support for ``tcp://`` in ``wait-for``
 
 `1.0.0`_ (2016-01-27)
 ---------------------

--- a/docs/wait-for.rst
+++ b/docs/wait-for.rst
@@ -24,6 +24,8 @@ successful response.
    | ``postgresql``      | Fail unless connecting `psycopg2`_ to the    |
    |                     | URL succeeds.                                |
    +---------------------+----------------------------------------------+
+   | ``tcp``             | Fail unless connecting a TCP socket succeeds.|
+   +---------------------+----------------------------------------------+
 
 .. option:: -s <seconds>, --sleep <seconds>
 


### PR DESCRIPTION
This PR adds support for waiting on an arbitrary TCP socket in `wait-for`