### PR TITLE
Bump cassandra-driver

### DIFF
--- a/bandoleers/__init__.py
+++ b/bandoleers/__init__.py
@@ -1,2 +1,2 @@
-version_info = (1, 1, 1)
+version_info = (1, 1, 2)
 __version__ = '.'.join(str(s) for s in version_info)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`1.1.2`_ (2017-03-23)
+---------------------
+- Bump cassandra-driver to >=3.0,<4.0
+
 `1.1.1`_ (2016-08-17)
 ---------------------
 - Support Python 2.6
@@ -50,7 +54,8 @@ Release History
 - Initial release of the PrepIt package
 - Import @briank's work on prepit.
 
-.. _Next Release: https://github.com/aweber/bandoleers/compare/1.1.1...HEAD
+.. _Next Release: https://github.com/aweber/bandoleers/compare/1.1.2...HEAD
+.. _1.1.2: https://github.com/aweber/bandoleers/compare/1.1.1...1.1.2
 .. _1.1.1: https://github.com/aweber/bandoleers/compare/1.1.0...1.1.1
 .. _1.1.0: https://github.com/aweber/bandoleers/compare/1.0.0...1.1.0
 .. _1.0.0: https://github.com/aweber/bandoleers/compare/0.3.5...1.0.0

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,4 +1,4 @@
-cassandra-driver>=2.5.1,<3.0
+cassandra-driver>=3.0,<4.0
 consulate>=0.5.1,<2.0
 psycopg2>=2.6,<3.0
 queries>=1.7.3,<2.0


### PR DESCRIPTION
`cassandra-driver` has trouble with Python 2.7.11+

See: https://issues.apache.org/jira/browse/CASSANDRA-11850