### PR TITLE
Add support for HTTP in prep-it.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,4 +29,5 @@ intersphinx_mapping = {
     'rejected': ('http://rejected.readthedocs.org/en/latest/', None),
     'consulate': ('http://consulate.readthedocs.org/en/latest/', None),
     'datastax': ('http://datastax.github.io/python-driver', None),
+    'requests': ('http://requests.readthedocs.io/en/master/', None),
 }

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Add raw HTTP support to ``prep-it``
+
 `2.0.0`_ (2017-05-22)
 ---------------------
 - Remove Cassandra support

--- a/docs/prep-it.rst
+++ b/docs/prep-it.rst
@@ -40,6 +40,36 @@ that are loaded into a Consul key-value store using a :class:`consulate.Consul`
 instance.  The Consul endpoint is configured by setting the
 :envvar:`CONSUL_HOST` and :envvar:`CONSUL_PORT` environment variables.
 
+http
+----
+JSON files containing an array of objects, one per request.  Each object
+is simply a list of parameters passed into :func:`requests.request`.  The
+following properties are usually what you want:
+
+:url:
+   The targetted resource.  This may be modified as described below.
+
+:method:
+   The HTTP method to request.
+
+:params:
+   Optional dictionary of query parameters.
+
+:headers:
+   Optional dictionary of headers to send.
+
+:json:
+   Optional body that will be JSON encoded before being sent.
+
+The ``url`` value may contain environment variables in the host and/or
+port number values.  For example ``http://$CONSUL_HOST:$CONSUL_PORT/...``
+is rewritten to ``http://127.0.0.1:37832`` if the :envvar:`CONSUL_HOST`
+environment variable is set to ``127.0.0.1`` and the :envvar:`CONSUL_PORT`
+environment variable is set to ``37832``.
+
+The user name and password parameters are removed from the URL and placed
+into the ``auth`` keyword parameter if they are present in the URL.
+
 rabbitmq
 --------
 JSON files that contain RabbitMQ HTTP API commands to execute.  Each


### PR DESCRIPTION
The PR adds support for making arbitrary HTTP requests from within `prep-it`.  The file structure is a simple JSON array of objects that are passed to [requests.request](http://docs.python-requests.org/en/master/api/#requests.request) after some simple modification.  I split out the user and password URL parameters and placed then in an `auth` parameter (where they should be) and expand `$ENV_VAR` strings in the URL.