### PR TITLE
Ignore temporary files in input directories.

### DIFF
--- a/bandoleers/prepit.py
+++ b/bandoleers/prepit.py
@@ -165,6 +165,8 @@ def run():
             path = '/'.join([opts.directory, resource])
             files = os.listdir(path)
             for data_file in files:
+                if data_file.startswith('.') or data_file.endswith('~'):
+                    continue
                 resources[resource]('/'.join([path, data_file]))
     LOGGER.info('Finished processing successfully.')
     sys.exit(0)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,8 @@ Release History
 `Next Release`_
 ---------------
 - Add raw HTTP support to ``prep-it``
+- Ignore data files that look like temporary files.  This specifcally
+  ignores files that start with a period and files that end with a tilde.
 
 `2.0.0`_ (2017-05-22)
 ---------------------


### PR DESCRIPTION
This has bitten me more times that I can count so I might as well fix it for [HacktoberFest](https://hacktoberfest.digitalocean.com).