### PR TITLE
Queries 2.x upgrade

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2017 AWeber Communications
+Copyright (c) 2016-2018 AWeber Communications
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/bandoleers/prepit.py
+++ b/bandoleers/prepit.py
@@ -11,12 +11,11 @@ for more details.
 import logging
 import os.path
 import re
-import socket
 import sys
 try:
-    from urllib.parse import parse_qsl, urlsplit, urlunsplit
+    from urllib.parse import urlsplit, urlunsplit
 except ImportError:
-    from urlparse import parse_qsl, urlsplit, urlunsplit
+    from urlparse import urlsplit, urlunsplit
 
 from redis import StrictRedis
 import consulate

--- a/bandoleers/waitfor.py
+++ b/bandoleers/waitfor.py
@@ -2,7 +2,6 @@
 Wait for a URL to become available.
 
 """
-import asyncore
 import logging
 import socket
 import sys

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,7 @@ Release History
 `Next Release`_
 ---------------
 - Upgrade to queries 2.0.x.
+- Drop support for Python 2.6.
 
 `2.1.0`_ (2017-10-28)
 ---------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Upgrade to queries 2.0.x.
+
 `2.1.0`_ (2017-10-28)
 ---------------------
 - Add raw HTTP support to ``prep-it``

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,5 +1,5 @@
 consulate>=0.5.1,<2.0
 psycopg2>=2.6,<3.0
-queries>=1.7.3,<2.0
+queries>=1.7.3,<2.1
 requests>=2.5.1,<3.0
 redis>=2.0.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setuptools.setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
This PR loosens the pin for queries to allow versions up to 2.1.0.  It also drops support for Python 2.6 since it is no longer supported by queries.