### PR TITLE
Replace queries with psycopg2

### DIFF
--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,5 +1,4 @@
 consulate>=0.5.1,<2
 psycopg2>=2.6,<3
-queries>=1.7.3,<2.1
 requests>=2.5.1,<3
 redis>=2,<4


### PR DESCRIPTION
Using `queries` unnecessarily complicates this package and limits one to using using `psycopg2<2.8`. Plain psycopg2 is sufficient.