### PR TITLE
Use psycopg2-binary

### DIFF
--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,4 +1,4 @@
 consulate>=0.5.1,<2
-psycopg2>=2.6,<3
+psycopg2-binary>=2.6,<3
 requests>=2.5.1,<3
 redis>=2,<4


### PR DESCRIPTION
Currently installing bandoleers is broken. Psycopg2 throws dozens of errors on install.

From the psycopg2 pypi page: 

"Building Psycopg requires a few prerequisites (a C compiler, some development packages)

You can also obtain a stand-alone package, not requiring a compiler or external libraries, by installing the psycopg2-binary package from PyPI:

`$ pip install psycopg2-binary`

The binary package is a practical choice for development and testing but in production it is advised to use the package built from sources."

As we exclusively use bandoleers for development I think this is a safe change.