### PR TITLE
Allow redis 5, bump version to 3.3.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2022 AWeber Communications
+Copyright (c) 2016-2023 AWeber Communications
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/bandoleers/__init__.py
+++ b/bandoleers/__init__.py
@@ -1,2 +1,2 @@
-version_info = (3, 3, 1)
+version_info = (3, 3, 2)
 __version__ = '.'.join(str(s) for s in version_info)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,10 @@ Release History
 `Next Release`_
 ---------------
 
+`3.3.2`_ (2023-11-29)
+---------------------
+- Loosen redis pin to allow redis 5
+
 `3.3.1`_ (2022-08-23)
 ---------------------
 - Loosen redis pin to allow redis 4
@@ -86,7 +90,8 @@ Release History
 - Initial release of the PrepIt package
 - Import @briank's work on prepit.
 
-.. _Next Release: https://github.com/aweber/bandoleers/compare/3.3.1...HEAD
+.. _Next Release: https://github.com/aweber/bandoleers/compare/3.3.2...HEAD
+.. _3.3.1: https://github.com/aweber/bandoleers/compare/3.3.1...3.3.2
 .. _3.3.1: https://github.com/aweber/bandoleers/compare/3.3.0...3.3.1
 .. _3.3.0: https://github.com/aweber/bandoleers/compare/3.2.0...3.3.0
 .. _3.2.0: https://github.com/aweber/bandoleers/compare/3.1.0...3.2.0

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,3 +1,3 @@
 psycopg2>=2.6,<3
 requests>=2.5.1,<3
-redis>=2,<5
+redis>=2,<6

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,8 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )


### PR DESCRIPTION
- Loosen redis pin to <6
- Bump version to 3.3.2 and copyright date to 2023
- Add newer python versions to classifiers